### PR TITLE
Check for errors mapping PR->patchwork

### DIFF
--- a/cibase.py
+++ b/cibase.py
@@ -512,7 +512,12 @@ class PatchworkSetup(CiBase):
             # signal success so these tests get run.
             self.success()
 
-        CiBase.patchwork = Patchwork(self.user, self.args.repo, self.args.pr_num)
+        try:
+            CiBase.patchwork = Patchwork(self.user, self.args.repo, self.args.pr_num)
+        except Exception as e:
+            self.ldebug("Unable to find matching patchwork entry, skipping")
+            self.skip()
+            return
 
         # Initialize as pending
         for t in CiBase.suite.values():

--- a/patchwork.py
+++ b/patchwork.py
@@ -107,6 +107,10 @@ class Patchwork:
 		gh_repo = Github(gh_token).get_repo(repo)
 		self.gh_pr = gh_repo.get_pull(pr)
 		sid = get_sid(self.gh_pr.title)
+
+		if not sid:
+			raise Exception("Unable to find series ID")
+
 		self.series = get_series(sid)
 
 		print(self.series)


### PR DESCRIPTION
If a PR is submitted to the test repo itself there will be no patchwork entry. This is really only relavent when changing CI related scripts, but is still nice to flow through the PR path.